### PR TITLE
Feature: Cart item orders never change

### DIFF
--- a/src/Cart.php
+++ b/src/Cart.php
@@ -196,11 +196,9 @@ class Cart
 
         // if the item is already in the cart we will just update it
         if ($cart->has($id)) {
-
             $this->update($id, $item);
         } else {
-
-            $this->addRow($id, $item);
+            $this->addItem($id, $item);
         }
 
         $this->currentItemId = $id;
@@ -225,7 +223,7 @@ class Cart
 
         $cart = $this->getContent();
 
-        $item = $cart->pull($id);
+        $item = $cart->get($id);
 
         foreach ($data as $key => $value) {
             // if the key is currently "quantity" we will need to check if an arithmetic
@@ -255,6 +253,7 @@ class Cart
             }
         }
 
+        // update the item in the cart
         $cart->put($id, $item);
 
         $this->save($cart);
@@ -725,7 +724,7 @@ class Cart
      *
      * @return bool
      */
-    protected function addRow($id, $item)
+    protected function addItem($id, $item)
     {
         if ($this->fireEvent('adding', $item) === false) {
             return false;

--- a/src/CartCollection.php
+++ b/src/CartCollection.php
@@ -4,6 +4,4 @@ namespace Wearepixel\Cart;
 
 use Illuminate\Support\Collection;
 
-class CartCollection extends Collection
-{
-}
+class CartCollection extends Collection {}

--- a/src/Exceptions/UnknownModelException.php
+++ b/src/Exceptions/UnknownModelException.php
@@ -2,6 +2,4 @@
 
 namespace Wearepixel\Cart\Exceptions;
 
-class UnknownModelException extends \Exception
-{
-}
+class UnknownModelException extends \Exception {}

--- a/tests/Helpers/ConfigMock.php
+++ b/tests/Helpers/ConfigMock.php
@@ -1,8 +1,7 @@
 <?php
 
 return [
-    'format_numbers' => false,
+    'format_numbers' => true,
     'decimals' => 2,
-    'dec_point' => '.',
-    'thousands_sep' => ',',
+    'round_mode' => 'up',
 ];


### PR DESCRIPTION
This PR stops cart items from being re-ordered when they are updated.

Fixes #1.