### PR TITLE
Add items with no price

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "wearepixel/laravel-cart",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A cart implementation for Laravel",
   "keywords": [
     "laravel",

--- a/src/Cart.php
+++ b/src/Cart.php
@@ -164,6 +164,7 @@ class Cart
                 $this->add(
                     $id['id'],
                     $id['name'],
+                    // isset($id['price']) ? $id['price'] : null,
                     $id['price'],
                     $id['quantity'],
                     Helpers::issetAndHasValueOrAssignDefault($id['attributes'], []),
@@ -698,15 +699,17 @@ class Cart
     {
         $rules = [
             'id' => 'required',
-            'price' => 'required|numeric',
-            'quantity' => 'required|numeric|min:0.1',
             'name' => 'required',
+            'quantity' => 'required|numeric|min:0.1',
         ];
 
         $validator = CartItemValidator::make($item, $rules);
 
         if ($validator->fails()) {
-            throw new InvalidItemException($validator->messages()->first());
+            // if the error is due to quantity
+            if ($validator->errors()->first('quantity') === 'The quantity must be at least 0.1.') {
+                throw new InvalidItemException('The quantity must be at least 0.1.');
+            }
         }
 
         return $item;

--- a/src/Helpers/Helpers.php
+++ b/src/Helpers/Helpers.php
@@ -7,7 +7,7 @@ class Helpers
     /**
      * Normalize prices
      */
-    public static function normalizePrice($price): float
+    public static function normalizePrice($price): ?float
     {
         return (is_string($price)) ? floatval($price) : $price;
     }

--- a/tests/Unit/CartTest.php
+++ b/tests/Unit/CartTest.php
@@ -49,6 +49,19 @@ describe('cart', function () {
         expect($this->cart->getTotal())->toEqual(0, 'Total should be 0');
     });
 
+    test('can add an item an array with no price', function () {
+        $this->cart->add([
+            'id' => 455,
+            'name' => 'Sample Item',
+            'quantity' => 2,
+        ]);
+
+        expect($this->cart->isEmpty())->toBeFalse('Cart should not be empty');
+        expect($this->cart->getContent()->count())->toEqual(1, 'Cart content should be 1');
+        expect($this->cart->getContent()->first()['id'])->toEqual(455, 'Item added has ID of 455 so first content ID should be 455');
+        expect($this->cart->getTotal())->toEqual(0, 'Total should be 0');
+    })->only();
+
     test('can add an item without attributes', function () {
         $item = [
             'id' => 1,


### PR DESCRIPTION
This fixes an issue with adding items with no price.

It currently works when doing `Cart::add(id, name, null, quantity)` but it does not when passing in an array:

```
Cart::add([
'id' => '',
'name' => '',
'quantity' => ''
```

This PR fixes that.