### PR TITLE
fix: add PHPStan/Larastan support to CartFacade

### DIFF
--- a/src/Facades/CartFacade.php
+++ b/src/Facades/CartFacade.php
@@ -3,10 +3,40 @@
 namespace Wearepixel\Cart\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use Wearepixel\Cart\Cart;
+use Wearepixel\Cart\CartCollection;
+use Wearepixel\Cart\CartCondition;
+use Wearepixel\Cart\CartConditionCollection;
+use Wearepixel\Cart\ItemCollection;
 
+/**
+ * @mixin Cart
+ *
+ * @method static ItemCollection|null get(int|string $itemId)
+ * @method static bool has(int|string $itemId)
+ * @method static void add(int|string $id, string $name, int|float $price, int $quantity, array $attributes = [], CartCondition|array $conditions = [], string $associatedModel = '')
+ * @method static bool update(int|string $id, array $data)
+ * @method static void remove(int|string $id)
+ * @method static void clear()
+ * @method static void clearItems()
+ * @method static Cart condition(array|CartCondition $condition)
+ * @method static CartConditionCollection|array getConditions(bool $array = false, bool $active = false)
+ * @method static CartCondition|null getCondition(string $conditionName)
+ * @method static CartConditionCollection getConditionsByType(string $type)
+ * @method static void removeConditionsByType(string $type)
+ * @method static void removeCartCondition(string $conditionName)
+ * @method static void clearItemConditions(int|string $itemId)
+ * @method static void clearAllConditions()
+ * @method static CartCollection getContent()
+ * @method static bool isEmpty()
+ * @method static int getTotalQuantity()
+ * @method static int|float|string getSubTotal(bool $formatted = true)
+ * @method static int|float|string getSubTotalWithoutConditions(bool $formatted = true)
+ * @method static int|float getTotal()
+ */
 class CartFacade extends Facade
 {
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return 'cart';
     }


### PR DESCRIPTION
## Summary

- Adds `@mixin Cart` and full `@method` PHPDoc annotations to `CartFacade`
- Adds return type to `getFacadeAccessor()`

## Why

Larastan reports errors like `Call to an undefined static method CartFacade::get()` because the cart is bound via a closure in the ServiceProvider, which PHPStan cannot statically resolve.

The `@mixin Cart` annotation tells PHPStan to look for methods on the underlying `Cart` class. The `@method` annotations provide explicit types for all public methods.

## Test plan

- [ ] PHPStan/Larastan on a consuming project reports no CartFacade errors